### PR TITLE
Use weights_only for load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - {python: "3.9", torch: "1.12"}
+          - {python: "3.9", torch: "1.13"}
           - {python: "3.10", torch: "2.0"}
           - {python: "3.11", torch: "2.2"}
           - {python: "3.12", torch: "2.4"}

--- a/azula/plugins/adm/__init__.py
+++ b/azula/plugins/adm/__init__.py
@@ -187,7 +187,7 @@ def load_model(key: str, **kwargs) -> ImprovedDenoiser:
         state = torch.load(
             f=cached_download(url=url),
             **kwargs,
-        )
+        weights_only=True)
     else:
         state = torch.hub.load_state_dict_from_url(
             url=url,

--- a/azula/plugins/adm/__init__.py
+++ b/azula/plugins/adm/__init__.py
@@ -186,8 +186,7 @@ def load_model(key: str, **kwargs) -> ImprovedDenoiser:
     if "drive.google" in url:
         state = torch.load(
             f=cached_download(url=url),
-            **kwargs,
-        weights_only=True)
+            **kwargs)
     else:
         state = torch.hub.load_state_dict_from_url(
             url=url,

--- a/azula/plugins/adm/__init__.py
+++ b/azula/plugins/adm/__init__.py
@@ -186,7 +186,8 @@ def load_model(key: str, **kwargs) -> ImprovedDenoiser:
     if "drive.google" in url:
         state = torch.load(
             f=cached_download(url=url),
-            **kwargs)
+            **kwargs,
+        )
     else:
         state = torch.hub.load_state_dict_from_url(
             url=url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 einops>=0.7.0
 numpy>=1.20.0
-torch>=1.12.0
-torchvision>=0.13
+torch>=1.13.0
+torchvision>=0.14.0

--- a/tests/test_nn_unet.py
+++ b/tests/test_nn_unet.py
@@ -65,7 +65,7 @@ def test_UNet(
 
     # Load
     copy = make()
-    copy.load_state_dict(torch.load(tmp_path / "state.pth"))
+    copy.load_state_dict(torch.load(tmp_path / "state.pth", weights_only=True))
 
     unet.eval()
     copy.eval()


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/