### PR TITLE
Add implementation for JiT Denoiser

### DIFF
--- a/tests/test_denoise.py
+++ b/tests/test_denoise.py
@@ -103,7 +103,7 @@ class ReSchedule(Schedule):
         return torch.ones_like(alpha), sigma / alpha
 
 
-@pytest.mark.parametrize("denoiser_cls", [SimpleDenoiser, KarrasDenoiser])
+@pytest.mark.parametrize("denoiser_cls", [SimpleDenoiser, KarrasDenoiser, JiTDenoiser])
 @pytest.mark.parametrize("schedule_cls", [VPSchedule, RectifiedSchedule])
 @pytest.mark.parametrize("with_label", [False, True])
 @pytest.mark.parametrize("batch", [(), (64,)])
@@ -146,47 +146,6 @@ def test_denoisers(
         q_ve = denoiser(x_t / alpha_t, t)
 
     assert torch.allclose(q.mean, q_ve.mean, atol=1e-6)
-
-    # Loss
-    if with_label:
-        loss = denoiser.loss(x, t, label="cat")
-    else:
-        loss = denoiser.loss(x, t)
-
-    assert loss.shape == ()
-    assert loss.requires_grad
-
-    loss.mean().backward()
-
-    for p in denoiser.parameters():
-        assert p.grad is not None
-        assert torch.all(torch.isfinite(p.grad))
-
-
-@pytest.mark.parametrize("with_label", [False, True])
-@pytest.mark.parametrize("batch", [(), (64,)])
-@pytest.mark.parametrize("channels", [5])
-def test_JiTDenoiser(with_label: bool, batch: Sequence[int], channels: int):
-    class JitSchedule(nn.Module):
-        def forward(self, t: Tensor):
-            return t, 1 - t
-
-    denoiser = JiTDenoiser(
-        backbone=Dummy(channels, with_label),
-        schedule=JitSchedule(),
-    )
-
-    # Forward
-    x = torch.randn(*batch, channels)
-    t = torch.sigmoid(torch.randn(batch) * 0.8 + 0.8)
-
-    if with_label:
-        q = denoiser(x, t, label="cat")
-    else:
-        q = denoiser(x, t)
-
-    assert isinstance(q, DiracPosterior)
-    assert q.mean.shape == x.shape
 
     # Loss
     if with_label:


### PR DESCRIPTION
It has been fun exploring all the capabilities of Azula and trying to understand all the different approaches to implementing Score-based diffusion models. With the recent [JiT Paper](https://arxiv.org/abs/2511.13720) I thought it would be good to test my understanding and thinking about how this could fit into Azula. I am not sure if this is of interest, but I read the contribution guide and thought I would give it a shot, and get feedback.